### PR TITLE
New regime updates

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,6 +18,10 @@
 
 		if (scheme === 'new') {
 			// New Tax Regime
+			if (taxableIncome <= 1275000) {
+				const professionalTax = 200 * 12;
+				return professionalTax;
+			}
 			if (taxableIncome > 2400000) {
 				tax += (taxableIncome - 2400000) * 0.3;
 				taxableIncome = 2400000;


### PR DESCRIPTION
Add logic to handle new tax regime for taxable income up to 12.75 Lakh.

* Add condition to check if taxable income is less than or equal to 12.75 Lakh and return professional tax only
* Retain existing logic for taxable income above 24 Lakh in the new tax regime

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sushil-kamble/income-tax-calci/pull/1?shareId=cf734a9b-d325-4ba9-847c-48841f583d0a).